### PR TITLE
Adds A Fallback Accessibility Label to Number Forms

### DIFF
--- a/Classes/MUFormNumberFieldCell.m
+++ b/Classes/MUFormNumberFieldCell.m
@@ -52,6 +52,11 @@
     self.staticLabel.text = [[NSBundle mainBundle] localizedStringForKey:localizedKey value:localizedKey table:MUFormKitStringTable];
     self.maxCharacters = [info[MUFormMaximumCharactersKey] integerValue];
     
+    // Give the number field an accessibility label if it has no text to use.
+    if (!self.numberField.hasText && !self.numberField.placeholder.length) {
+        self.numberField.accessibilityLabel = self.staticLabel.text;
+    }
+    
     NSArray *validationMessages = info[MUValidationMessagesKey];
     self.messageLabel.text = ([validationMessages count] > 0) ? validationMessages[0] : nil;
 


### PR DESCRIPTION
This relates to one of the items (Age text field) in https://github.com/meetup/meetup-ios/issues/3151

By giving the number label a default value when it would otherwise have
none, we provide helpful context when tapping into the field. This
seemed applicable to the accessibility of all fields, so I’ve placed
the pull request here so that every number form cell can receive this
accessibility benefit.