### PR TITLE
Remove Reference to Main App Method

### DIFF
--- a/Classes/MUFormTextViewCell.m
+++ b/Classes/MUFormTextViewCell.m
@@ -149,9 +149,4 @@ static const CGFloat MUFormTextViewNumberOfLines = 3.0f;
     }
 }
 
-- (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text {
-    [textView scrollToCursorIfNecessaryForReplacementText:text];
-    return YES;
-}
-
 @end


### PR DESCRIPTION
The `scrollToCursorIfNecessaryForReplacementText` method only exists in
the main Meetup app and should not be relied on by this dependency.

It’s safe to remove now because it only applied to iOS 7 and we’ve
dropped that OS in the main app.